### PR TITLE
Add auth to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pip install jupyter
 Finally, install `Jupyter::Kernel`:
 
 ```
-zef install Jupyter::Kernel
+zef install 'Jupyter::Kernel:auth<zef:bduggan>'
 ```
 
 At the end of the above installation, you'll see the location


### PR DESCRIPTION
This change adds the `auth` portion to the installation instructions.  Currently, running `zef install Jupyter::Kernel` finds `Jupyter::Chatbook` before this one; since `Jupyter::Kernel` is also in the `provides` section of the [META6.json](https://github.com/antononcube/Raku-Jupyter-Chatbook/blob/master/META6.json#L31) for that module and the precedence in zef is a little unclear.

Not sure if there's a better way to handle this .. @antononcube, any ideas?  I think ideally Chatbook would be in a separate namespace -- this would also make it easier for both installations to exist at once on the same host, and it would be easier to choose one of the two kernels from within jupyter.
