### PR TITLE
mime type to text/x-raku

### DIFF
--- a/lib/Jupyter/Kernel.rakumod
+++ b/lib/Jupyter/Kernel.rakumod
@@ -20,7 +20,7 @@ has $.kernel-info = {
     language_info => {
         name => 'raku',
         version => ~$*RAKU.version,
-        mimetype => 'text/plain',
+        mimetype => 'text/x-raku',
         file_extension => '.raku',
     },
     banner => "Welcome to Raku 🦋 ({ $*RAKU.compiler.name } { $*RAKU.compiler.version })."

--- a/lib/Jupyter/Kernel/Magics.rakumod
+++ b/lib/Jupyter/Kernel/Magics.rakumod
@@ -30,8 +30,7 @@ class Magic::Filter {
         $str;
     }
     method mime-type {
-        # text/plain by default
-        'text/plain';
+        'text/plain'
     }
 }
 class Magic::Filter::HTML is Magic::Filter {


### PR DESCRIPTION
I was trying to get https://github.com/bscan/RakuNavigator to work with JupyterLab, but I had to change the mime types to make the language server work. See here [link](https://github.com/bscan/RakuNavigator/issues/13)

I do not know why oroginally you choose text/plain, but maybe for future development of e.g. a codemirrow plug-in for Raku it would be anyway a good move to be more specific.

Maybe I am getting it totaly wrong, in that case, we just forget about this PR ;-)

The other two PR I recently opened are just "side effects", perhaps this is usefull to you?