### PR TITLE
Fix macos issue from Jupyter::Chatbook

### DIFF
--- a/lib/Jupyter/Kernel/Paths.rakumod
+++ b/lib/Jupyter/Kernel/Paths.rakumod
@@ -11,7 +11,7 @@ sub data-dir is export {
         when .is-win {
             '%APPDATA%'.IO.child('jupyter')
         }
-        when .name eq 'macosx' {
+        when .name ~~ /macos/ {
             %*ENV<HOME>.IO.child('Library').child('Jupyter')
         }
         default {


### PR DESCRIPTION
Hi - I found an installation issue using `Jupyter::Chatbook` and was also able to reproduce with `Jupyter::Kernel<auth:bduggan>`.

This fixes the issue with macos cant find kernel

https://github.com/antononcube/Raku-Jupyter-Chatbook/issues/2